### PR TITLE
Update process.js: fix engine path issue on Ubuntu

### DIFF
--- a/server.js
+++ b/server.js
@@ -45,6 +45,7 @@ app.get("/getBestMove", (req, res) => {
         const parsedResult = {
             fen: result.fen,
             move: result.bestMove,
+            ponder: result.possibleHumanMove,
             turn: result.turn,
             depth: depth,
             movetime: movetime,

--- a/utils/process.js
+++ b/utils/process.js
@@ -7,7 +7,7 @@ const fs = require('fs');
 const executeEngine = (command, engineCmd = 'go depth 10', engine_name) => {
   return new Promise((resolve, reject) => {
     const engines_path = path.resolve(process.cwd(), 'utils/engine');
-    const engine_path = path.resolve(process.cwd(), 'utils/engine',engine_name);
+    const engine_path = path.resolve(engines_path, engine_name);
 
     if (!fs.existsSync(engine_path)) {
       reject("Engine not found: " + engine_name);
@@ -15,9 +15,9 @@ const executeEngine = (command, engineCmd = 'go depth 10', engine_name) => {
 
     console.log("Using engine: " + engine_name);
 
-    const engine = spawn(engine_name, { 
+    const engine = spawn(`"${engine_path}"`, { 
       shell: true,
-      cwd:engines_path
+      cwd: engines_path
     });
 
     engine.stdin.write(`${command}\n`);


### PR DESCRIPTION
For some reason, the code used to get executable path doesn't work correctly on Ubuntu.
```
#1) turn updated to: White using depth mode Using engine: stockfish-ubuntu Error: /bin/sh: 1: stockfish-ubuntu: not found
```

I tried to fix it.

Btw, how can I get the engine logs on Smart Chess Bot box for Node Server Engine?
I mostly used that to see the predicted move, instead use option display the moves on chessboard.
So only way know to see the move is view response content from Network Tab of Browser console, It is quite inconvenient.